### PR TITLE
removed the rewriting

### DIFF
--- a/lib/fastboot-build-deploy-plugin.js
+++ b/lib/fastboot-build-deploy-plugin.js
@@ -26,30 +26,6 @@ module.exports = DeployPlugin.extend({
       });
   },
 
-  didBuild: function(context) {
-    var fs = require('fs');
-    // Rewrite FastBoot index.html assets
-    try {
-      var browserAssetMap = JSON.parse(fs.readFileSync(context.distDir + '/assets/assetMap.json'));
-      var fastBootAssetMap = JSON.parse(fs.readFileSync(context.fastbootDistDir + '/assets/assetMap.json'));
-      var prepend = browserAssetMap.prepend;
-
-      var indexHTML = fs.readFileSync(context.fastbootDistDir + '/index.html').toString();
-      var newAssets = browserAssetMap.assets;
-      var oldAssets = fastBootAssetMap.assets;
-
-      for (var key in oldAssets) {
-        var value = oldAssets[key];
-        console.log(value);
-        indexHTML = indexHTML.replace(prepend + value, prepend + newAssets[key]);
-      }
-
-      fs.writeFileSync(context.fastbootDistDir + '/index.html', indexHTML);
-    } catch(e) {
-      this.log('unable to rewrite assets: ' + e.stack, { verbose: true });
-    }
-  },
-
   buildFastBoot: function(outputPath) {
     var buildEnv   = this.readConfig('environment');
 


### PR DESCRIPTION
Howdy Stanley!

I removed the rewriting from the plugin. You can actually accomplish this from the `ember-cli-build.js` as documented here: http://ember-cli.com/ember-cli-deploy/docs/v0.5.x/fingerprinting/

For reference, I have my ember-cli-build.js configured like this:

``` js
/*jshint node:true*/
/* global require, module */
var EmberApp = require('ember-cli/lib/broccoli/ember-app');
  var env = EmberApp.env() || 'development';

  var isProductionLikeBuild = ['production', 'staging'].indexOf(env) > -1;

  var fingerprintOptions = {
    enabled: true,
    extensions: ['js', 'css', 'png', 'jpg', 'gif', 'png']
  };

  switch (env) {
    case 'development':
      fingerprintOptions.prepend = 'http://localhost:4200/';
    break;
    case 'staging':
      fingerprintOptions.prepend = 'https://s3.amazonaws.com/staging-monegraph-apps-assets/';
    break;
    case 'production':
      fingerprintOptions.prepend = 'TODO';
    break;
                                                              }


module.exports = function(defaults) {
  var app = new EmberApp(defaults, {
    // Add options here
    fingerprint: fingerprintOptions,
    emberCLIDeploy: {
      //runOnPostBuild: (env === 'development') ? 'devindex' : false,
      shouldActivate: true
    },
    emberCliFontAwesome: {
      useScss: true
    }
  });

  // Use `app.import` to add additional libraries to the generated
  // output files.
  //
  // If you need to use different assets in different
  // environments, specify an object as the first parameter. That
  // object's keys should be the environment name and the values
  // should be the asset to use in that environment.
  //
  // If the library that you are including contains AMD or ES6
  // modules that you would like to import into your application
  // please specify an object with the list of modules as keys
  // along with the exports of each module as its value.

  return app.toTree();
};

```

the the following is generated from the `build` step:
<img width="1013" alt="screen shot 2016-02-24 at 11 00 34 pm" src="https://cloud.githubusercontent.com/assets/61075/13309415/874155fc-db4a-11e5-880c-51852431c78e.png">
