### PR TITLE
allow ember-cli-fastboot-build to run without ember-cli-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ be written to.
 For detailed information on what plugin hooks are and how they work, please refer to the [Plugin Documentation][plugin-documentation].
 
 - `build`
+- `didBuild`
 
 ## What is an ember-cli-deploy plugin?
 

--- a/lib/fastboot-build-deploy-plugin.js
+++ b/lib/fastboot-build-deploy-plugin.js
@@ -2,6 +2,7 @@
 
 var DeployPlugin = require('ember-cli-deploy-plugin');
 var path = require('path');
+var fs = require('fs');
 
 module.exports = DeployPlugin.extend({
   defaultConfig: {
@@ -15,10 +16,22 @@ module.exports = DeployPlugin.extend({
 
     return this.buildFastBoot(outputPath)
       .then(function(files) {
-        return {
-          fastbootDistDir: outputPath,
-          fastbootDistFiles: files || []
-        };
+        var distDir = self.readConfig('distDir');
+        if (!fs.existsSync(distDir)) {
+          //this is the scenario where there is only the fastboot build
+          //and no traditional ember build step in the build pipeline
+          //in that case the build files should go into the primary dist properties so downstream
+          //steps don't have to look in a different place
+          return {
+            distDir: outputPath,
+            distFiles: files || []
+          };
+        } else {
+          return {
+            fastbootDistDir: outputPath,
+            fastbootDistFiles: files || []
+          };
+        }
       })
       .catch(function(error) {
         self.log('build failed', { color: 'red' });
@@ -27,14 +40,22 @@ module.exports = DeployPlugin.extend({
   },
 
   didBuild: function(context) {
-    var fs = require('fs');
+    // For the scenario where users are opting to perform solely a fastboot build and no ember build step
+    // lets not do rewriting
+
+    if (!context.fastbootDistDir) { return; }
+
+    var emberBuildAssetMapPath = path.join(context.distDir, 'assets/assetMap.json');
+    var fastbootBuildAsssetMapPath = path.join(context.fastbootDistDir, 'assets/assetMap.json');
+
     // Rewrite FastBoot index.html assets
     try {
-      var browserAssetMap = JSON.parse(fs.readFileSync(context.distDir + '/assets/assetMap.json'));
-      var fastBootAssetMap = JSON.parse(fs.readFileSync(context.fastbootDistDir + '/assets/assetMap.json'));
+      var browserAssetMap = JSON.parse(fs.readFileSync(emberBuildAssetMapPath));
+      var fastBootAssetMap = JSON.parse(fs.readFileSync(fastbootBuildAsssetMapPath));
+      var fastbootIndexHtmlPath = path.join(context.fastbootDistDir, 'index.html');
       var prepend = browserAssetMap.prepend;
 
-      var indexHTML = fs.readFileSync(context.fastbootDistDir + '/index.html').toString();
+      var indexHTML = fs.readFileSync(fastbootIndexHtmlPath);
       var newAssets = browserAssetMap.assets;
       var oldAssets = fastBootAssetMap.assets;
 
@@ -44,7 +65,7 @@ module.exports = DeployPlugin.extend({
         indexHTML = indexHTML.replace(prepend + value, prepend + newAssets[key]);
       }
 
-      fs.writeFileSync(context.fastbootDistDir + '/index.html', indexHTML);
+      fs.writeFileSync(fastbootIndexHtmlPath, indexHTML);
     } catch(e) {
       this.log('unable to rewrite assets: ' + e.stack, { verbose: true });
     }

--- a/lib/fastboot-build-deploy-plugin.js
+++ b/lib/fastboot-build-deploy-plugin.js
@@ -55,7 +55,7 @@ module.exports = DeployPlugin.extend({
       var fastbootIndexHtmlPath = path.join(context.fastbootDistDir, 'index.html');
       var prepend = browserAssetMap.prepend;
 
-      var indexHTML = fs.readFileSync(fastbootIndexHtmlPath);
+      var indexHTML = fs.readFileSync(fastbootIndexHtmlPath).toString();
       var newAssets = browserAssetMap.assets;
       var oldAssets = fastBootAssetMap.assets;
 


### PR DESCRIPTION
Here's a better PR. It allows for the scenario when you want to run both `ember-cli-build` and `ember-cli-fastboot-build` build steps and need to reconcile the url rewriting in the fastboot index file, as well as the scenario where you want to only do an `ember-cli-fastboot-build`, in which case you wont need to do that rewriting step, as the `ember-cli-build.js` file can take care of that for you. Also, in the case where you want to solely do the `ember-cli-fastboot-build`, i'm putting the outputs into the `distDir` and `distDirFiles` properties so that downstream steps don't have to be adjusted to look in a different place for the build outputs (really cleans up the `deploy.js` file)
