### PR TITLE
distDir should be read off context, instead of using `readConfig`

### DIFF
--- a/lib/fastboot-build-deploy-plugin.js
+++ b/lib/fastboot-build-deploy-plugin.js
@@ -10,13 +10,13 @@ module.exports = DeployPlugin.extend({
     outputPath: path.join('tmp', 'fastboot-dist')
   },
 
-  build: function() {
+  build: function(context) {
     var outputPath = this.readConfig('outputPath');
     var self = this;
 
     return this.buildFastBoot(outputPath)
       .then(function(files) {
-        var distDir = self.readConfig('distDir');
+        var distDir = context.distDir;
         if (!fs.existsSync(distDir)) {
           //this is the scenario where there is only the fastboot build
           //and no traditional ember build step in the build pipeline


### PR DESCRIPTION
Using `readConfig` seemed to return undefined for `distDir` sometimes,
even when `ember-cli-deploy-build` was present. Instead, it's always
available through ember-cli-deploy's `context` object.
